### PR TITLE
Add product search function

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,6 +4,7 @@
 @import "mixin/order";
 @import 'modules/items/index';
 @import "modules/items/new";
+@import "modules/items/search";
 @import "modules/items/show";
 @import "modules/layouts/app-banner";
 @import "modules/layouts/breadcrumbs";

--- a/app/assets/stylesheets/modules/items/_index.scss
+++ b/app/assets/stylesheets/modules/items/_index.scss
@@ -217,8 +217,8 @@
                   letter-spacing: 3px;
                 &:before{
                   font-family: "Font Awesome 5 Free"; 
-                  font-weight: 900;
-                  content: "\f005";
+                  font-weight: normal;
+                  content: "\f004";
                   }
                 }
               }

--- a/app/assets/stylesheets/modules/items/_search.scss
+++ b/app/assets/stylesheets/modules/items/_search.scss
@@ -1,0 +1,82 @@
+.search-container{
+  overflow: hidden;
+  margin: 40px auto 0;
+  width: 1020px;
+  .narrow-search-results{
+    float: left;
+    width: 280px;
+    margin: 0 40px 0 0;
+    background-color: #aaa;
+    height: 100vh;
+  }
+  .show-search-results{
+    float: right;
+    width: 700px;
+    .search-results{
+      h2{
+        font-size: 22px;
+        margin-bottom: 8px;
+        span{
+          font-size: 18px;
+          margin-right: 4px;
+        }
+      }
+      &__number{
+        margin: 16px 0;
+        font-size: 12px;
+        color: #888;
+      }
+      &__items{
+        overflow: hidden;
+        .item{
+          float: left;
+          width: 160px;
+          height: 265px;
+          margin: 0 20px 20px 0;
+          background-color: #fff;
+          &:nth-child(4n){
+            margin: 0;
+          }
+          a{
+            text-decoration: none;
+            display: block;
+            img{
+              width: 100%;
+              height: 150px;
+              object-fit: cover;
+            }
+            .item__info{
+              color: #333;
+              line-height: 1.5;
+              padding: 16px;
+              &__name{
+                font-size: 16px;
+                text-align: left;
+              }
+            }
+            .item__info__details{
+              font-size: 16px;
+              ul{
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                .likes{
+                  letter-spacing: 1px;
+                &:before{
+                  font-family: "Font Awesome 5 Free"; 
+                  font-weight: normal;
+                  content: "\f004";
+                  }
+                }
+              }
+              p{
+                font-size: 10px;
+                text-align: left;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/layouts/_serch-box.scss
+++ b/app/assets/stylesheets/modules/layouts/_serch-box.scss
@@ -51,11 +51,20 @@ header{
         display: flex;
         a{
           color: #333;
-          font-size: 13px;
           text-decoration: none;
           padding-right: 46px;
+          display: flex;
           &:hover{
             color: $orangeColor;
+          }
+          figure{
+            margin-right: 8px;
+            .icon{
+              img{
+                width: 20px;
+                vertical-align: text-bottom;
+              }
+            }
           }
         }
       }

--- a/app/assets/stylesheets/modules/layouts/_serch-box.scss
+++ b/app/assets/stylesheets/modules/layouts/_serch-box.scss
@@ -59,8 +59,8 @@ header{
           }
           figure{
             margin-right: 8px;
-            .icon{
-              img{
+            .menu-icon{
+              &__img{
                 width: 20px;
                 vertical-align: text-bottom;
               }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -39,6 +39,11 @@ class ItemsController < ApplicationController
     end
   end
 
+  def search
+    @keyword = params[:search]
+    @items = Item.includes(:item_images).search(@keyword).order('created_at DESC').limit(132)
+  end
+
   private
   
   def item_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,5 +12,10 @@ class Item < ApplicationRecord
   def already_liked(user_id)
     likes.find_by(user_id: user_id)
   end
+
+  def self.search(keyword)
+    return Item.all unless keyword
+    Item.where('name LIKE ?', "%#{keyword}%")
+  end
 end
 

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -5,11 +5,12 @@
         = image_tag item_image.image.url
     .item__info
       %h3.item__info__name
-        = item.name
+        = item.name.truncate(14)
       .item__info__details
         %ul
           %li.price
             = item.price
             円
-          %li.likes 0
+          %li.likes
+            = item.likes.count
         %p （税込）

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -1,0 +1,27 @@
+%header
+  = render 'layouts/search-box'
+.search-container
+  .narrow-search-results
+  .show-search-results
+    %section.search-results
+      - if @keyword.present? && @items.present?
+        %h2 
+          = @keyword
+          %span の検索結果
+        .search-results__number
+          = "1 - #{@items.count} 件表示"
+      - elsif @keyword.present? && @items.empty?
+        %h2
+          = @keyword
+          %span に該当する商品は見つかりませんでした
+        .search-results__empty
+          = "検索条件を変えて、再度お試しください"
+      - else
+        %h2 検索結果
+        .search-results__number
+          = "1 - #{@items.count} 件表示"
+      .search-results__items
+        = render partial: 'item', collection: @items
+= render 'layouts/app-banner'
+= render 'layouts/footer'
+= render 'layouts/publish-btn'

--- a/app/views/layouts/_search-box.html.haml
+++ b/app/views/layouts/_search-box.html.haml
@@ -10,8 +10,16 @@
             = image_tag 'icon/icon-search 1.png'
   .header-nav
     .header-nav__left-box
-      = link_to 'カテゴリー', '#', class: 'header-nav__left-box--category'
-      = link_to 'ブランド', '#', class: 'header-nav__left-box--brand'
+      = link_to '#', class: 'header-nav__left-box--category' do
+        %figure
+          .icon
+            = image_tag 'icon/icon_category.png'
+        %span カテゴリー
+      = link_to '#', class: 'header-nav__left-box--brand' do
+        %figure
+          .icon
+            = image_tag 'icon/icon_brand.png'
+        %span ブランド
     .header-nav__right-box
       -if user_signed_in?
         = link_to user_likes_path(current_user.id), class: 'header-nav__right-box--likes' do

--- a/app/views/layouts/_search-box.html.haml
+++ b/app/views/layouts/_search-box.html.haml
@@ -12,13 +12,13 @@
     .header-nav__left-box
       = link_to '#', class: 'header-nav__left-box--category' do
         %figure
-          .icon
-            = image_tag 'icon/icon_category.png'
+          .menu-icon
+            = image_tag 'icon/icon_category.png', class: 'menu-icon__img'
         %span カテゴリー
       = link_to '#', class: 'header-nav__left-box--brand' do
         %figure
-          .icon
-            = image_tag 'icon/icon_brand.png'
+          .menu-icon
+            = image_tag 'icon/icon_brand.png', class: 'menu-icon__img'
         %span ブランド
     .header-nav__right-box
       -if user_signed_in?

--- a/app/views/layouts/_search-box.html.haml
+++ b/app/views/layouts/_search-box.html.haml
@@ -3,7 +3,7 @@
     = link_to root_path, class: 'home-btn' do
       = image_tag 'logo/logo.png'
     .search-section
-      = form_with url: root_path do |f|
+      = form_with url: search_items_path, method: :get, local: true do |f|
         = f.text_field :search, placeholder: 'キーワードから探す', class: 'search-section__input-box'
         %button{type: "submit", class:'search-section__submit-btn'}
           .serch-icon

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     collection do
       get 'category/get_children_categories', to: 'items#get_children_categories', defaults: { format: 'json' }
       get 'category/get_grandchildren_categories', to: 'items#get_grandchildren_categories', defaults: { format: 'json' }
+      get 'search'
     end
     resources :likes, only: [ :create, :destroy]
   end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+
+  factory :category do
+    name {"カテゴリー"}
+  end
+
+end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+
+  factory :item do
+    name {"アイテム"}
+    description {"商品説明"}
+    brand {"ブランド"}
+    price {"1000"}
+  end
+
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+  describe Item do
+    describe '#search' do
+      it "itemのnameカラムにkeywordと同じ文字列を含む場合はレコードを取得" do
+        keyword = "テスト"
+        user = create(:user)
+        category = create(:category)
+        item = create(:item, user_id: user.id, category_id: category.id)
+        item1 = create(:item, name: "テスト", user_id: user.id, category_id: category.id)
+        item2 = create(:item, name: "単体テスト", user_id: user.id, category_id: category.id)
+        item3 = create(:item, name: "単体テスト3", user_id: user.id, category_id: category.id)
+        expect(Item.search(keyword)).to include(item1, item2, item3)
+      end
+
+      it "itemのnameカラムにkeywordと同じ文字列を含まない場合はレコードを取得しない" do
+        keyword = "キーワード"
+        user = create(:user)
+        category = create(:category)
+        item = create(:item, user_id: user.id, category_id: category.id)
+        item1 = create(:item, name: "テスト", user_id: user.id, category_id: category.id)
+        item2 = create(:item, name: "単体テスト", user_id: user.id, category_id: category.id)
+        item3 = create(:item, name: "単体テスト3", user_id: user.id, category_id: category.id)
+        expect(Item.search(keyword)).to be_empty
+      end
+
+      it "キーワードがない場合は全てのレコードを取得" do
+        keyword = ""
+        user = create(:user)
+        category = create(:category)
+        item = create(:item, user_id: user.id, category_id: category.id)
+        item1 = create(:item, name: "テスト", user_id: user.id, category_id: category.id)
+        item2 = create(:item, name: "単体テスト", user_id: user.id, category_id: category.id)
+        item3 = create(:item, name: "単体テスト3", user_id: user.id, category_id: category.id)
+        expect(Item.search(keyword)).to include(item, item1, item2, item3)
+      end
+    end
+  end


### PR DESCRIPTION
# What
商品のあいまい検索機能を実装

# Why
探したいものをダイレクトで検索できるようにするため

# ScreenShot
### 検索キーワードなし
[![Screenshot from Gyazo](https://gyazo.com/9de13ee999d58fad799927ccf4cab166/raw)](https://gyazo.com/9de13ee999d58fad799927ccf4cab166)

### 該当商品あり
[![Screenshot from Gyazo](https://gyazo.com/e765a53bc30bc6234f2e7d21d3db1231/raw)](https://gyazo.com/e765a53bc30bc6234f2e7d21d3db1231)

### 該当商品なし
[![Screenshot from Gyazo](https://gyazo.com/ec5d950e3b02fb3aea6b759704ee19d3/raw)](https://gyazo.com/ec5d950e3b02fb3aea6b759704ee19d3)
※画面左のグレー背景部分は詳細検索の領域にします