### PR TITLE
Add sold out display

### DIFF
--- a/app/assets/stylesheets/modules/items/_search.scss
+++ b/app/assets/stylesheets/modules/items/_search.scss
@@ -141,6 +141,27 @@
           a{
             text-decoration: none;
             display: block;
+            position: relative;
+            .sold-out-bnr{
+              width: 0;
+              height: 0;
+              border-width: 80px 80px 0 0;
+              border-color: #ea352d transparent;
+              border-style: solid;
+              position: absolute;
+              top: 0;
+              left: 0;
+              &__inner{
+                top: -60px;
+                font-size: 20px;
+                position: absolute;
+                left: 0;
+                color: #fff;
+                transform: rotate(-45deg);
+                letter-spacing: 2px;
+                font-weight: 600;
+              }
+            }
             img{
               width: 100%;
               height: 150px;

--- a/app/assets/stylesheets/modules/items/_show.scss
+++ b/app/assets/stylesheets/modules/items/_show.scss
@@ -23,6 +23,27 @@ tr {
       height: 100%;
       background-color: $body_back;
       padding-bottom:20px;
+      position: relative;
+      .sold-out-bnr{
+        width: 0;
+        height: 0;
+        border-width: 120px 120px 0 0;
+        border-color: #ea352d transparent;
+        border-style: solid;
+        position: absolute;
+        top: 0;
+        left: 0;
+        &__inner{
+          top: -90px;
+          font-size: 30px;
+          position: absolute;
+          left: 0;
+          color: #fff;
+          transform: rotate(-45deg);
+          letter-spacing: 2px;
+          font-weight: 600;
+        }
+      }
       &--top{
         img {
           display: block;

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -1,5 +1,8 @@
 .item
   = link_to item_path(item.id) do
+    -if item.buyer_id.present? 
+      .sold-out-bnr
+        %p.sold-out-bnr__inner SOLD
     - item.item_images.each_with_index do |item_image, i|
       - if i == 0
         = image_tag item_image.image.url

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -5,6 +5,9 @@
     =  @item.name
   .item-content.clearfix
     .item-content__photo
+      -if @item.buyer_id.present? 
+        .sold-out-bnr
+          %p.sold-out-bnr__inner SOLD
       .item-content__photo--top
         = image_tag @item.item_images[0].image.url
       .item-content__photo--bottom


### PR DESCRIPTION
# What
売り切れ商品に sold out バナーを表示
# Why
一目で商品の販売状況がわかるようにするため
# ScreenShot
[![Screenshot from Gyazo](https://gyazo.com/fcb2e4569f7cb87a50623c97a3580b45/raw)](https://gyazo.com/fcb2e4569f7cb87a50623c97a3580b45)
[![Screenshot from Gyazo](https://gyazo.com/fd9b6f4fb124b933d1af0b31a1cfb39e/raw)](https://gyazo.com/fd9b6f4fb124b933d1af0b31a1cfb39e)