### PR TITLE
button_fix

### DIFF
--- a/app/assets/stylesheets/modules/items/_show.scss
+++ b/app/assets/stylesheets/modules/items/_show.scss
@@ -135,7 +135,7 @@ tr {
       font-size: 16px;
     }
   }
-  .item-buy-btn{
+  .buy-btn{
     display: block;
     margin-top: 16px;
     background: #ea352d;


### PR DESCRIPTION
# What
- 商品詳細ページの「購入画面に進む」がボタンとして機能していなかった為修正。

# Why
- 見た目がボタンに仕上がっており、軽度の修正で可能と考えた為。
- 実際のところCSSのクラス名を変更しただけでボタンとして機能しました。

https://gyazo.com/d5b747d4078c03ef1afa2ea9b8ae3e0d